### PR TITLE
Fix IikoEventTypeNotFoundException name

### DIFF
--- a/src/Application/Iiko/Factories/WebhookEventDataFactory.php
+++ b/src/Application/Iiko/Factories/WebhookEventDataFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Application\Iiko\Factories;
 
 use Domain\Iiko\Enums\WebhookEventType;
-use Domain\Iiko\Exceptions\IikoEventTypeNotFountException;
+use Domain\Iiko\Exceptions\IikoEventTypeNotFoundException;
 use Presentation\Api\DataTransferObjects;
 use Presentation\Api\Requests\IikoWebhookRequest;
 use Spatie\LaravelData\Data;
@@ -17,7 +17,7 @@ final readonly class WebhookEventDataFactory
         return match ($request->eventType->value) {
             WebhookEventType::DELIVERY_ORDER_UPDATE->value => DataTransferObjects\DeliveryOrderUpdateData\EventData::from($request->eventInfo),
             WebhookEventType::STOP_LIST_UPDATE->value => DataTransferObjects\StopListUpdateData\EventData::from(['organizationId' => $request->organizationId, 'items' => $request->eventInfo['terminalGroupsStopListsUpdates']]),
-            default => throw new IikoEventTypeNotFountException(),
+            default => throw new IikoEventTypeNotFoundException(),
         };
     }
 }

--- a/src/Application/Iiko/Factories/WebhookEventFactory.php
+++ b/src/Application/Iiko/Factories/WebhookEventFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Application\Iiko\Factories;
 
 use Domain\Iiko\Enums\WebhookEventType;
-use Domain\Iiko\Exceptions\IikoEventTypeNotFountException;
+use Domain\Iiko\Exceptions\IikoEventTypeNotFoundException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Infrastructure\Persistence\Eloquent\Settings\Models\OrganizationSetting;
@@ -34,7 +34,7 @@ final readonly class WebhookEventFactory
         $eventMap = WebhookEventType::eventMap();
 
         if (! array_key_exists($request->eventType->value, $eventMap)) {
-            throw new IikoEventTypeNotFountException();
+            throw new IikoEventTypeNotFoundException();
         }
 
         $this->dispatcher->dispatch(

--- a/src/Domain/Iiko/Exceptions/IikoEventTypeNotFoundException.php
+++ b/src/Domain/Iiko/Exceptions/IikoEventTypeNotFoundException.php
@@ -6,4 +6,4 @@ namespace Domain\Iiko\Exceptions;
 
 use Illuminate\Contracts\Debug\ShouldntReport;
 
-final class IikoEventTypeNotFountException extends \DomainException implements ShouldntReport {}
+final class IikoEventTypeNotFoundException extends \DomainException implements ShouldntReport {}

--- a/tests/Feature/WebhookOrderStressTest.php
+++ b/tests/Feature/WebhookOrderStressTest.php
@@ -6,7 +6,7 @@ ini_set('memory_limit', '-1');
 
 use function Pest\Stressless\stress;
 
-it('Webhook Order Stress Test', static function () {
+it('Webhook Order Stress Test', function () {
     $result = stress(route('api.v1.iiko.webhook'))
         ->post(['name' => 'Nuno'])
         ->concurrency(1)

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-test('that true is true', static function () {
+test('that true is true', function () {
     expect(true)->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- rename `IikoEventTypeNotFountException` to `IikoEventTypeNotFoundException`
- update factories to use the new exception
- fix Pest static closures in the sample tests

## Testing
- `composer dump-autoload --no-scripts`
- `composer install --no-scripts --no-progress --no-interaction`
- `./vendor/bin/pest --no-coverage`

------
https://chatgpt.com/codex/tasks/task_b_68590d14fe1c832ca9aa142e7bc845eb