### PR TITLE
Add WebhookEventDataFactory tests

### DIFF
--- a/src/Application/Iiko/Factories/WebhookEventDataFactory.php
+++ b/src/Application/Iiko/Factories/WebhookEventDataFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Application\Iiko\Factories;
 
 use Domain\Iiko\Enums\WebhookEventType;
-use Domain\Iiko\Exceptions\IikoEventTypeNotFountException;
+use Domain\Iiko\Exceptions\IikoEventTypeNotFoundException;
 use Presentation\Api\DataTransferObjects;
 use Presentation\Api\Requests\IikoWebhookRequest;
 use Spatie\LaravelData\Data;
@@ -17,7 +17,7 @@ final readonly class WebhookEventDataFactory
         return match ($request->eventType->value) {
             WebhookEventType::DELIVERY_ORDER_UPDATE->value => DataTransferObjects\DeliveryOrderUpdateData\EventData::from($request->eventInfo),
             WebhookEventType::STOP_LIST_UPDATE->value => DataTransferObjects\StopListUpdateData\EventData::from(['organizationId' => $request->organizationId, 'items' => $request->eventInfo['terminalGroupsStopListsUpdates']]),
-            default => throw new IikoEventTypeNotFountException(),
+            default => throw new IikoEventTypeNotFoundException(),
         };
     }
 }

--- a/src/Application/Iiko/Factories/WebhookEventFactory.php
+++ b/src/Application/Iiko/Factories/WebhookEventFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Application\Iiko\Factories;
 
 use Domain\Iiko\Enums\WebhookEventType;
-use Domain\Iiko\Exceptions\IikoEventTypeNotFountException;
+use Domain\Iiko\Exceptions\IikoEventTypeNotFoundException;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Infrastructure\Persistence\Eloquent\Settings\Models\OrganizationSetting;
@@ -34,7 +34,7 @@ final readonly class WebhookEventFactory
         $eventMap = WebhookEventType::eventMap();
 
         if (! array_key_exists($request->eventType->value, $eventMap)) {
-            throw new IikoEventTypeNotFountException();
+            throw new IikoEventTypeNotFoundException();
         }
 
         $this->dispatcher->dispatch(

--- a/src/Domain/Iiko/Exceptions/IikoEventTypeNotFoundException.php
+++ b/src/Domain/Iiko/Exceptions/IikoEventTypeNotFoundException.php
@@ -6,4 +6,4 @@ namespace Domain\Iiko\Exceptions;
 
 use Illuminate\Contracts\Debug\ShouldntReport;
 
-final class IikoEventTypeNotFountException extends \DomainException implements ShouldntReport {}
+final class IikoEventTypeNotFoundException extends \DomainException implements ShouldntReport {}

--- a/tests/Unit/WebhookEventDataFactoryTest.php
+++ b/tests/Unit/WebhookEventDataFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Application\Iiko\Factories\WebhookEventDataFactory;
+use Carbon\CarbonImmutable;
+use Domain\Iiko\Enums\WebhookEventType;
+use Domain\Iiko\Exceptions\IikoEventTypeNotFoundException;
+use Presentation\Api\Requests\IikoWebhookRequest;
+use Presentation\Api\DataTransferObjects\DeliveryOrderUpdateData\EventData as DeliveryOrderUpdateEventData;
+use Presentation\Api\DataTransferObjects\StopListUpdateData\EventData as StopListUpdateEventData;
+use Mockery;
+
+afterEach(function (): void {
+    Mockery::close();
+});
+
+test('known event types return the correct data object class', function () {
+    $factory = new WebhookEventDataFactory();
+
+    $deliveryRequest = new IikoWebhookRequest(
+        WebhookEventType::DELIVERY_ORDER_UPDATE,
+        CarbonImmutable::now(),
+        'org',
+        'corr',
+        ['key' => 'value']
+    );
+
+    $stopListRequest = new IikoWebhookRequest(
+        WebhookEventType::STOP_LIST_UPDATE,
+        CarbonImmutable::now(),
+        'org',
+        'corr',
+        ['terminalGroupsStopListsUpdates' => []]
+    );
+
+    $deliveryData = new stdClass();
+    $stopListData = new stdClass();
+
+    Mockery::mock('alias:'.DeliveryOrderUpdateEventData::class)
+        ->shouldReceive('from')
+        ->once()
+        ->with($deliveryRequest->eventInfo)
+        ->andReturn($deliveryData);
+
+    Mockery::mock('alias:'.StopListUpdateEventData::class)
+        ->shouldReceive('from')
+        ->once()
+        ->with(['organizationId' => $stopListRequest->organizationId, 'items' => $stopListRequest->eventInfo['terminalGroupsStopListsUpdates']])
+        ->andReturn($stopListData);
+
+    $resultDelivery = $factory->fromRequest($deliveryRequest);
+    $resultStopList = $factory->fromRequest($stopListRequest);
+
+    expect($resultDelivery)->toBe($deliveryData);
+    expect($resultStopList)->toBe($stopListData);
+});
+
+test('unknown event type throws exception', function () {
+    $factory = new WebhookEventDataFactory();
+
+    $request = new IikoWebhookRequest(
+        WebhookEventType::RESERVE_UPDATE,
+        CarbonImmutable::now(),
+        'org',
+        'corr',
+        []
+    );
+
+    $factory->fromRequest($request);
+})->throws(IikoEventTypeNotFoundException::class);


### PR DESCRIPTION
## Summary
- add tests to cover WebhookEventDataFactory
- rename IikoEventTypeNotFoundException and update factories

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68590d5bfb48832c945a5d0eb8d02afd