### PR TITLE
fix: cast restaurant id in WelcomeGroup order import error

### DIFF
--- a/src/Application/WelcomeGroup/Services/ImportOrderService.php
+++ b/src/Application/WelcomeGroup/Services/ImportOrderService.php
@@ -108,7 +108,13 @@ final readonly class ImportOrderService
                     'error' => $e,
                 ]);
 
-                throw new WelcomeGroupImportOrdersGeneralException("Не удалось инициировать процесс сбора заказов из ПОД в IIKO. Заведение: {$organizationSetting->welcomeGroupRestaurantId->id}. Причина: {$e->getMessage()}");
+                throw new WelcomeGroupImportOrdersGeneralException(
+                    sprintf(
+                        'Не удалось инициировать процесс сбора заказов из ПОД в IIKO. Заведение: %d. Причина: %s',
+                        $organizationSetting->welcomeGroupRestaurantId->id,
+                        $e->getMessage(),
+                    ),
+                );
             }
         });
     }


### PR DESCRIPTION
## Summary
- fix object-to-string error when reporting restaurant ID in ImportOrderService

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68591248d39c832c8d962e8ca6813855